### PR TITLE
dotCMS/core#11984 updated connectionTimeout property

### DIFF
--- a/conf/server.xml
+++ b/conf/server.xml
@@ -67,7 +67,7 @@
          Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
     -->
     <Connector port="8080" protocol="HTTP/1.1"
-               connectionTimeout="20000"
+               connectionTimeout="60000"
                redirectPort="8443" URIEncoding="UTF-8"/>
     <!-- A "Connector" using the shared thread pool-->
     <!--


### PR DESCRIPTION
Tested on backported fix to 3.7.1 and using fixes from dotCMS/core#11913. Working as expected. 

See related ticket dotCMS/core#11984 for more details on how to test.