### PR TITLE
dotCMS/core#21393 Adding missing flag in case catalina.sh is used

### DIFF
--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+JAVA_OPTS="$JAVA_OPTS -Dlog4j2.formatMsgNoLookups=true "


### PR DESCRIPTION
Setting the flag on the setenv.sh will make it visible in catalina.sh and startup.sh