### PR TITLE
(#21568): Adding java necessary '--add-opens' options to permit unsafe access for xstream reflection

### DIFF
--- a/bin/catalina.sh
+++ b/bin/catalina.sh
@@ -324,9 +324,15 @@ if [ "$USE_NOHUP" = "true" ]; then
 fi
 
 # Add the JAVA 9 specific start-up parameters required by Tomcat
-JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/java.lang=ALL-UNNAMED"
 JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/java.io=ALL-UNNAMED"
+JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/java.lang=ALL-UNNAMED"
+JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED"
+JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"
+JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/jdk.internal.module=ALL-UNNAMED"
+JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED"
+JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED"
 JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED"
+
 export JDK_JAVA_OPTIONS
 
 # ----- Execute The Requested Command -----------------------------------------


### PR DESCRIPTION
Sibling PRs:
https://github.com/dotCMS/enterprise/pull/854
https://github.com/dotCMS/core/pull/21752